### PR TITLE
Add initial client setup and structure

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,0 +1,64 @@
+package reader
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const (
+	defaultBaseURL = "https://readwise.io/api/v3"
+	defaultTimeout = 30 * time.Second
+)
+
+// Client interface for interacting with Readwise Reader API
+type Client interface {
+	ListDocuments(ctx context.Context, opts *ListDocumentsOptions) (*ListDocumentsResponse, error)
+}
+
+// client is the implementation of the Client interface
+type client struct {
+	baseURL    string
+	token      string
+	httpClient *http.Client
+}
+
+// NewClient creates a new Readwise Reader client
+func NewClient(token string) (Client, error) {
+	if token == "" {
+		return nil, &ClientError{
+			Type:    "invalid_token",
+			Message: "token cannot be empty",
+		}
+	}
+
+	return &client{
+		baseURL: defaultBaseURL,
+		token:   token,
+		httpClient: &http.Client{
+			Timeout: defaultTimeout,
+		},
+	}, nil
+}
+
+// ClientError represents an error from the client
+type ClientError struct {
+	Type    string
+	Message string
+}
+
+func (e *ClientError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Type, e.Message)
+}
+
+// APIError represents an error from the Readwise Reader API
+type APIError struct {
+	StatusCode int
+	Message    string
+	Details    map[string]interface{}
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("API error (status %d): %s", e.StatusCode, e.Message)
+}

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,60 @@
+package reader
+
+import (
+	"testing"
+)
+
+func TestNewClient(t *testing.T) {
+	tests := []struct {
+		name    string
+		token   string
+		wantErr bool
+	}{
+		{
+			name:    "valid token",
+			token:   "valid-token",
+			wantErr: false,
+		},
+		{
+			name:    "empty token",
+			token:   "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := NewClient(tt.token)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewClient() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && client == nil {
+				t.Errorf("NewClient() returned nil client")
+			}
+		})
+	}
+}
+
+func TestClientError(t *testing.T) {
+	err := &ClientError{
+		Type:    "test_error",
+		Message: "test message",
+	}
+	expected := "test_error: test message"
+	if err.Error() != expected {
+		t.Errorf("expected error %s, got %s", expected, err.Error())
+	}
+}
+
+func TestAPIError(t *testing.T) {
+	err := &APIError{
+		StatusCode: 400,
+		Message:    "Bad Request",
+		Details:    map[string]interface{}{"field": "error"},
+	}
+	expected := "API error (status 400): Bad Request"
+	if err.Error() != expected {
+		t.Errorf("expected error %s, got %s", expected, err.Error())
+	}
+}

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,29 @@
+// Package reader provides a Go client library for the Readwise Reader API.
+//
+// This package allows you to interact with Readwise Reader's API to manage
+// your saved documents, articles, and reading list.
+//
+// Basic usage:
+//
+//	client, err := reader.NewClient(token)
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+//
+//	documents, err := client.ListDocuments(ctx, &reader.ListDocumentsOptions{
+//		Limit: 10,
+//	})
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+//
+// Authentication:
+//
+// You need a Readwise Reader API token to use this package. You can get one
+// from https://readwise.io/reader_api
+//
+// Set your token as an environment variable:
+//
+//	export READWISE_ACCESS_TOKEN="your-token-here"
+//
+package reader

--- a/list.go
+++ b/list.go
@@ -1,0 +1,27 @@
+package reader
+
+import "context"
+
+// ListDocumentsOptions holds options for listing documents
+type ListDocumentsOptions struct {
+	// TODO: Add actual fields like Limit, Category, UpdatedAfter
+}
+
+// ListDocumentsResponse represents the response from ListDocuments
+type ListDocumentsResponse struct {
+	// TODO: Add actual fields like Count, Next, Previous, Results
+}
+
+// Document represents a document in Readwise Reader
+type Document struct {
+	// TODO: Add actual fields like ID, Title, URL, etc.
+}
+
+// ListDocuments retrieves documents from Readwise Reader
+func (c *client) ListDocuments(ctx context.Context, opts *ListDocumentsOptions) (*ListDocumentsResponse, error) {
+	// TODO: Implement actual API call
+	return nil, &ClientError{
+		Type:    "not_implemented",
+		Message: "ListDocuments not implemented yet",
+	}
+}


### PR DESCRIPTION
## Summary
- Add basic client interface and implementation structure
- Create foundation for Readwise Reader API client library  
- Include error types and basic validation
- Set up proper Go project structure following best practices

## Changes
- `client.go`: Client interface and constructor with validation
- `client_test.go`: Unit tests for client creation and error types
- `doc.go`: Package documentation with usage examples
- `list.go`: Placeholder structure for ListDocuments API