### PR TITLE
feat: implement Phase3 - Create Document API

### DIFF
--- a/_example/main.go
+++ b/_example/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -19,15 +20,33 @@ func main() {
 		log.Fatalf("failed to create reader client: %v", err)
 	}
 
-	documents, err := readerClient.ListDocuments(&reader.ListDocumentsOptions{
-		Limit: 10,
-	})
+	ctx := context.Background()
 
+	// Example 1: Create a new document
+	fmt.Println("Creating a new document...")
+	title := "Example Article"
+	category := "article"
+	
+	createResp, err := readerClient.CreateDocument(ctx, &reader.CreateDocumentRequest{
+		URL:      "https://example.com/interesting-article",
+		Title:    &title,
+		Category: &category,
+	})
 	if err != nil {
-		log.Fatalf("failed to get highlights: %v", err)
+		log.Fatalf("failed to create document: %v", err)
+	}
+	
+	fmt.Printf("Created document: ID=%s, Title=%s, URL=%s\n", 
+		createResp.ID, createResp.Title, createResp.URL)
+
+	// Example 2: List documents
+	fmt.Println("\nListing documents...")
+	documents, err := readerClient.ListDocuments(ctx, &reader.ListDocumentsOptions{})
+	if err != nil {
+		log.Fatalf("failed to get documents: %v", err)
 	}
 
-	for _, document := range documents {
-		fmt.Printf("%v\n", document)
+	for _, document := range documents.Results {
+		fmt.Printf("Document: %+v\n", document)
 	}
 }

--- a/client.go
+++ b/client.go
@@ -15,6 +15,7 @@ const (
 // Client interface for interacting with Readwise Reader API
 type Client interface {
 	ListDocuments(ctx context.Context, opts *ListDocumentsOptions) (*ListDocumentsResponse, error)
+	CreateDocument(ctx context.Context, req *CreateDocumentRequest) (*CreateDocumentResponse, error)
 }
 
 // client is the implementation of the Client interface

--- a/create.go
+++ b/create.go
@@ -1,0 +1,107 @@
+package reader
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// CreateDocumentRequest holds the parameters for creating a document
+type CreateDocumentRequest struct {
+	// URL is the URL of the document to create (required)
+	URL string `json:"url"`
+	
+	// Title is the optional title for the document
+	Title *string `json:"title,omitempty"`
+	
+	// Category is the optional category for the document
+	Category *string `json:"category,omitempty"`
+}
+
+// CreateDocumentResponse represents the response from creating a document
+type CreateDocumentResponse struct {
+	// ID is the unique identifier of the created document
+	ID string `json:"id"`
+	
+	// URL is the URL of the document
+	URL string `json:"url"`
+	
+	// Title is the title of the document
+	Title string `json:"title"`
+	
+	// Category is the category of the document
+	Category string `json:"category"`
+	
+	// CreatedAt is the creation timestamp
+	CreatedAt string `json:"created_at"`
+	
+	// UpdatedAt is the last update timestamp
+	UpdatedAt string `json:"updated_at"`
+}
+
+// CreateDocument creates a new document in Readwise Reader
+func (c *client) CreateDocument(ctx context.Context, req *CreateDocumentRequest) (*CreateDocumentResponse, error) {
+	if req == nil {
+		return nil, &ClientError{
+			Type:    "invalid_request",
+			Message: "request cannot be nil",
+		}
+	}
+	
+	if req.URL == "" {
+		return nil, &ClientError{
+			Type:    "invalid_request", 
+			Message: "URL is required",
+		}
+	}
+	
+	// Marshal the request to JSON
+	requestBody, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+	
+	// Create the HTTP request
+	url := fmt.Sprintf("%s/documents/", c.baseURL)
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(requestBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	
+	// Set headers
+	httpReq.Header.Set("Authorization", "Token "+c.token)
+	httpReq.Header.Set("Content-Type", "application/json")
+	
+	// Execute the request
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+	
+	// Check for API errors
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		var apiErr map[string]interface{}
+		if err := json.NewDecoder(resp.Body).Decode(&apiErr); err == nil {
+			return nil, &APIError{
+				StatusCode: resp.StatusCode,
+				Message:    fmt.Sprintf("failed to create document"),
+				Details:    apiErr,
+			}
+		}
+		return nil, &APIError{
+			StatusCode: resp.StatusCode,
+			Message:    fmt.Sprintf("failed to create document: status %d", resp.StatusCode),
+		}
+	}
+	
+	// Parse the response
+	var createResp CreateDocumentResponse
+	if err := json.NewDecoder(resp.Body).Decode(&createResp); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+	
+	return &createResp, nil
+}

--- a/create_example_test.go
+++ b/create_example_test.go
@@ -1,0 +1,88 @@
+package reader_test
+
+import (
+	"context"
+	"log"
+	"os"
+
+	reader "github.com/tcnksm/go-readwise-reader"
+)
+
+func ExampleClient_CreateDocument() {
+	// Get the API token from environment variable
+	token := os.Getenv("READWISE_ACCESS_TOKEN")
+	if token == "" {
+		log.Fatal("READWISE_ACCESS_TOKEN environment variable is required")
+	}
+
+	// Create a new client
+	client, err := reader.NewClient(token)
+	if err != nil {
+		log.Fatalf("Failed to create client: %v", err)
+	}
+
+	// Create a new document with minimal information (URL only)
+	ctx := context.Background()
+	response, err := client.CreateDocument(ctx, &reader.CreateDocumentRequest{
+		URL: "https://example.com/interesting-article",
+	})
+	if err != nil {
+		log.Fatalf("Failed to create document: %v", err)
+	}
+
+	log.Printf("Created document with ID: %s", response.ID)
+}
+
+func ExampleClient_CreateDocument_withTitle() {
+	token := os.Getenv("READWISE_ACCESS_TOKEN")
+	if token == "" {
+		log.Fatal("READWISE_ACCESS_TOKEN environment variable is required")
+	}
+
+	client, err := reader.NewClient(token)
+	if err != nil {
+		log.Fatalf("Failed to create client: %v", err)
+	}
+
+	// Create a document with custom title
+	ctx := context.Background()
+	title := "My Custom Title"
+	response, err := client.CreateDocument(ctx, &reader.CreateDocumentRequest{
+		URL:   "https://example.com/article",
+		Title: &title,
+	})
+	if err != nil {
+		log.Fatalf("Failed to create document: %v", err)
+	}
+
+	log.Printf("Created document '%s' with ID: %s", response.Title, response.ID)
+}
+
+func ExampleClient_CreateDocument_withCategory() {
+	token := os.Getenv("READWISE_ACCESS_TOKEN")
+	if token == "" {
+		log.Fatal("READWISE_ACCESS_TOKEN environment variable is required")
+	}
+
+	client, err := reader.NewClient(token)
+	if err != nil {
+		log.Fatalf("Failed to create client: %v", err)
+	}
+
+	// Create a document with title and category
+	ctx := context.Background()
+	title := "Important Research Paper"
+	category := "research"
+	
+	response, err := client.CreateDocument(ctx, &reader.CreateDocumentRequest{
+		URL:      "https://example.com/research-paper",
+		Title:    &title,
+		Category: &category,
+	})
+	if err != nil {
+		log.Fatalf("Failed to create document: %v", err)
+	}
+
+	log.Printf("Created %s document '%s' with ID: %s", 
+		response.Category, response.Title, response.ID)
+}

--- a/create_test.go
+++ b/create_test.go
@@ -1,0 +1,245 @@
+package reader
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestClient_CreateDocument(t *testing.T) {
+	tests := []struct {
+		name           string
+		request        *CreateDocumentRequest
+		serverResponse string
+		statusCode     int
+		wantErr        bool
+		wantErrType    string
+	}{
+		{
+			name: "successful creation with all fields",
+			request: &CreateDocumentRequest{
+				URL:      "https://example.com/article",
+				Title:    stringPtr("Example Article"),
+				Category: stringPtr("article"),
+			},
+			serverResponse: `{
+				"id": "doc123",
+				"url": "https://example.com/article",
+				"title": "Example Article",
+				"category": "article",
+				"created_at": "2023-01-01T00:00:00Z",
+				"updated_at": "2023-01-01T00:00:00Z"
+			}`,
+			statusCode: 201,
+			wantErr:    false,
+		},
+		{
+			name: "successful creation with URL only",
+			request: &CreateDocumentRequest{
+				URL: "https://example.com/minimal",
+			},
+			serverResponse: `{
+				"id": "doc456",
+				"url": "https://example.com/minimal",
+				"title": "Minimal Article",
+				"category": "",
+				"created_at": "2023-01-01T00:00:00Z",
+				"updated_at": "2023-01-01T00:00:00Z"
+			}`,
+			statusCode: 201,
+			wantErr:    false,
+		},
+		{
+			name:        "nil request",
+			request:     nil,
+			wantErr:     true,
+			wantErrType: "*reader.ClientError",
+		},
+		{
+			name: "empty URL",
+			request: &CreateDocumentRequest{
+				URL: "",
+			},
+			wantErr:     true,
+			wantErrType: "*reader.ClientError",
+		},
+		{
+			name: "API error response",
+			request: &CreateDocumentRequest{
+				URL: "https://example.com/invalid",
+			},
+			serverResponse: `{
+				"error": "Invalid URL format"
+			}`,
+			statusCode:  400,
+			wantErr:     true,
+			wantErrType: "*reader.APIError",
+		},
+		{
+			name: "server error",
+			request: &CreateDocumentRequest{
+				URL: "https://example.com/article",
+			},
+			serverResponse: `Internal Server Error`,
+			statusCode:     500,
+			wantErr:        true,
+			wantErrType:    "*reader.APIError",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a test server
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Verify the request method and headers
+				if r.Method != "POST" {
+					t.Errorf("Expected POST request, got %s", r.Method)
+				}
+				
+				if r.Header.Get("Content-Type") != "application/json" {
+					t.Errorf("Expected Content-Type: application/json, got %s", r.Header.Get("Content-Type"))
+				}
+				
+				authHeader := r.Header.Get("Authorization")
+				if !strings.HasPrefix(authHeader, "Token ") {
+					t.Errorf("Expected Authorization header with Token prefix, got %s", authHeader)
+				}
+				
+				// Verify the request body for valid requests
+				if tt.request != nil && tt.request.URL != "" {
+					var body CreateDocumentRequest
+					if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+						t.Errorf("Failed to decode request body: %v", err)
+					}
+					
+					if body.URL != tt.request.URL {
+						t.Errorf("Expected URL %s, got %s", tt.request.URL, body.URL)
+					}
+				}
+				
+				// Send the test response
+				w.WriteHeader(tt.statusCode)
+				w.Write([]byte(tt.serverResponse))
+			}))
+			defer server.Close()
+
+			// Create a client with the test server URL
+			client := &client{
+				baseURL:    server.URL,
+				token:      "test-token",
+				httpClient: &http.Client{},
+			}
+
+			// Execute the method
+			ctx := context.Background()
+			result, err := client.CreateDocument(ctx, tt.request)
+
+			// Check error expectations
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateDocument() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr {
+				if tt.wantErrType != "" {
+					errType := getErrorType(err)
+					if errType != tt.wantErrType {
+						t.Errorf("Expected error type %s, got %s", tt.wantErrType, errType)
+					}
+				}
+				return
+			}
+
+			// Check success case
+			if result == nil {
+				t.Error("Expected non-nil result for successful case")
+				return
+			}
+
+			// Parse expected response for comparison
+			var expected CreateDocumentResponse
+			if err := json.Unmarshal([]byte(tt.serverResponse), &expected); err != nil {
+				t.Fatalf("Failed to parse expected response: %v", err)
+			}
+
+			if result.ID != expected.ID {
+				t.Errorf("Expected ID %s, got %s", expected.ID, result.ID)
+			}
+			if result.URL != expected.URL {
+				t.Errorf("Expected URL %s, got %s", expected.URL, result.URL)
+			}
+		})
+	}
+}
+
+func TestCreateDocumentRequest_Validation(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *CreateDocumentRequest
+		wantErr bool
+	}{
+		{
+			name: "valid request with all fields",
+			request: &CreateDocumentRequest{
+				URL:      "https://example.com",
+				Title:    stringPtr("Test"),
+				Category: stringPtr("article"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid request with URL only",
+			request: &CreateDocumentRequest{
+				URL: "https://example.com",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid request with empty URL",
+			request: &CreateDocumentRequest{
+				URL: "",
+			},
+			wantErr: true,
+		},
+	}
+
+	client := &client{
+		baseURL:    "https://api.example.com",
+		token:      "test-token",
+		httpClient: &http.Client{},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			_, err := client.CreateDocument(ctx, tt.request)
+			
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateDocument() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// Helper function to get error type as string
+func getErrorType(err error) string {
+	if err == nil {
+		return ""
+	}
+	switch err.(type) {
+	case *ClientError:
+		return "*reader.ClientError"
+	case *APIError:
+		return "*reader.APIError"
+	default:
+		return "unknown"
+	}
+}
+
+// Helper function to create string pointer
+func stringPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
Implements Phase3 from doc/TODO.md - Create Document API functionality

## Summary
- Add CreateDocument method to Client interface
- Implement create.go with proper request/response types
- Add comprehensive test suite with table-driven tests
- Add documentation examples for godoc
- Update example usage in _example/main.go

## API Design
- Required field: URL (string)
- Optional fields: Title (*string), Category (*string)
- Returns: Document details with ID, timestamps
- Proper error handling with ClientError and APIError types

Closes #4

Generated with [Claude Code](https://claude.ai/code)