### PR TITLE
Add GitHub workflow to delete merged branches

### DIFF
--- a/.github/workflows/delete-merged-branch.yml
+++ b/.github/workflows/delete-merged-branch.yml
@@ -1,0 +1,43 @@
+name: Delete Merged Branch
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  delete-branch:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    
+    steps:
+    - name: Delete merged branch
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const { owner, repo } = context.repo;
+          const branch = context.payload.pull_request.head.ref;
+          const headRepoOwner = context.payload.pull_request.head.repo?.owner?.login;
+          
+          // Only delete branches from the same repository
+          if (headRepoOwner === owner) {
+            try {
+              await github.rest.git.deleteRef({
+                owner: owner,
+                repo: repo,
+                ref: `heads/${branch}`
+              });
+              console.log(`✅ Successfully deleted branch: ${branch}`);
+            } catch (error) {
+              // Branch might already be deleted or protected
+              if (error.status === 422 || error.status === 404) {
+                console.log(`ℹ️  Branch ${branch} is protected or already deleted`);
+              } else {
+                throw error;
+              }
+            }
+          } else {
+            console.log(`ℹ️  Skipping deletion of branch from fork: ${headRepoOwner}/${branch}`);
+          }


### PR DESCRIPTION
## Summary
- Implements automated branch deletion for merged pull requests
- Adds a new GitHub Actions workflow that triggers when PRs are closed
- Only deletes branches from the same repository (not forks)

## Implementation Details
The workflow uses `actions/github-script` to safely delete branches after merge with proper error handling for:
- Protected branches (logs info message)
- Already deleted branches (logs info message)
- Branches from forks (skips deletion)

## Test plan
- [ ] Workflow syntax is valid
- [ ] Merge a test PR and verify the branch is deleted
- [ ] Ensure protected branches are not deleted
- [ ] Verify branches from forks are not affected

Fixes #20