### PR TITLE
Refactor CreateDocument to accept URL as separate parameter

### DIFF
--- a/client.go
+++ b/client.go
@@ -15,7 +15,7 @@ const (
 // Client interface for interacting with Readwise Reader API
 type Client interface {
 	ListDocuments(ctx context.Context, opts *ListDocumentsOptions) (*ListDocumentsResponse, error)
-	CreateDocument(ctx context.Context, req *CreateDocumentRequest) (*CreateDocumentResponse, error)
+	CreateDocument(ctx context.Context, url string, req *CreateDocumentRequest) (*CreateDocumentResponse, error)
 	UpdateDocument(ctx context.Context, documentID string, req *UpdateDocumentRequest) (*UpdateDocumentResponse, error)
 	DeleteDocument(ctx context.Context, documentID string) error
 }

--- a/create.go
+++ b/create.go
@@ -11,9 +11,6 @@ import (
 
 // CreateDocumentRequest represents the request to create a document
 type CreateDocumentRequest struct {
-	// URL is the unique URL of the document (required)
-	URL string `json:"url"`
-
 	// HTML is the document content in valid HTML format (optional)
 	HTML string `json:"html,omitempty"`
 
@@ -54,23 +51,29 @@ type CreateDocumentResponse struct {
 }
 
 // CreateDocument creates a new document in Readwise Reader
-func (c *client) CreateDocument(ctx context.Context, req *CreateDocumentRequest) (*CreateDocumentResponse, error) {
-	if req == nil {
-		return nil, &ClientError{
-			Type:    "invalid_request",
-			Message: "request cannot be nil",
-		}
-	}
-
-	if req.URL == "" {
+func (c *client) CreateDocument(ctx context.Context, url string, req *CreateDocumentRequest) (*CreateDocumentResponse, error) {
+	if url == "" {
 		return nil, &ClientError{
 			Type:    "invalid_request",
 			Message: "URL is required",
 		}
 	}
 
+	if req == nil {
+		req = &CreateDocumentRequest{}
+	}
+
+	// Create request body with URL and other fields
+	reqBody := struct {
+		URL string `json:"url"`
+		*CreateDocumentRequest
+	}{
+		URL:                   url,
+		CreateDocumentRequest: req,
+	}
+
 	// Prepare request body
-	body, err := json.Marshal(req)
+	body, err := json.Marshal(reqBody)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}

--- a/create_example_test.go
+++ b/create_example_test.go
@@ -15,14 +15,14 @@ func ExampleClient_CreateDocument() {
 		log.Fatal(err)
 	}
 
+	url := "https://example.com/article"
 	req := &reader.CreateDocumentRequest{
-		URL:   "https://example.com/article",
 		Title: "Interesting Article",
 		Tags:  []string{"golang", "api"},
 	}
 
 	ctx := context.Background()
-	resp, err := client.CreateDocument(ctx, req)
+	resp, err := client.CreateDocument(ctx, url, req)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -39,8 +39,8 @@ func ExampleClient_CreateDocument_withAllFields() {
 
 	publishedDate := time.Date(2023, 12, 1, 10, 0, 0, 0, time.UTC)
 
+	url := "https://example.com/complete-article"
 	req := &reader.CreateDocumentRequest{
-		URL:           "https://example.com/complete-article",
 		HTML:          "<html><body><h1>Complete Article</h1><p>Content here</p></body></html>",
 		Title:         "Complete Article Example",
 		Author:        "Jane Doe",
@@ -53,7 +53,7 @@ func ExampleClient_CreateDocument_withAllFields() {
 	}
 
 	ctx := context.Background()
-	resp, err := client.CreateDocument(ctx, req)
+	resp, err := client.CreateDocument(ctx, url, req)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
## Summary
- Refactored `CreateDocument` method to accept URL as a separate parameter
- Updated method signature from `CreateDocument(ctx, req)` to `CreateDocument(ctx, url, req)`
- Removed URL field from `CreateDocumentRequest` struct

## Motivation
Since URL is a required parameter for creating documents, it makes sense to have it as an explicit parameter rather than part of the request struct. This makes the API clearer and more consistent with other methods like `UpdateDocument` and `DeleteDocument` that take IDs as separate parameters.

## Changes
- Updated `Client` interface in `client.go`
- Modified `CreateDocumentRequest` struct to remove URL field in `create.go`
- Updated implementation to handle URL separately and create composite request body
- Updated all tests to use new signature
- Updated example code to demonstrate new usage

## Test Plan
- [x] All existing tests pass
- [x] Code formatted with `go fmt`
- [x] No issues from `go vet`