### PR TITLE
feat: implement CLI Phase 2 list command

### DIFF
--- a/cmd/reader/list.go
+++ b/cmd/reader/list.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/google/subcommands"
+	reader "github.com/tcnksm/go-readwise-reader"
+)
+
+type listCmd struct {
+	baseCommand
+}
+
+func (*listCmd) Name() string { return "list" }
+func (*listCmd) Synopsis() string {
+	return "List documents in new location"
+}
+func (*listCmd) Usage() string {
+	return `list:
+  List all documents in the new location.
+  Output is pretty-printed JSON array.
+`
+}
+func (*listCmd) SetFlags(f *flag.FlagSet) {}
+
+func (c *listCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+	// Initialize client
+	if err := c.initClient(ctx); err != nil {
+		printError(err)
+		return subcommands.ExitFailure
+	}
+
+	// Set up options for ListDocuments - Phase 2 lists only new location
+	opts := &reader.ListDocumentsOptions{
+		Location: reader.LocationNew,
+	}
+
+	// Call ListDocuments API
+	response, err := c.client.ListDocuments(ctx, opts)
+	if err != nil {
+		printError(fmt.Errorf("failed to list documents: %w", err))
+		return subcommands.ExitFailure
+	}
+
+	// Output documents as pretty JSON
+	// TODO: Handle pagination in future implementation
+	if err := printJSON(response.Results); err != nil {
+		printError(fmt.Errorf("failed to output JSON: %w", err))
+		return subcommands.ExitFailure
+	}
+
+	return subcommands.ExitSuccess
+}

--- a/cmd/reader/main.go
+++ b/cmd/reader/main.go
@@ -9,17 +9,6 @@ import (
 	"github.com/google/subcommands"
 )
 
-// Stub command types - will be implemented in Phase 2
-type listCmd struct{}
-
-func (*listCmd) Name() string             { return "list" }
-func (*listCmd) Synopsis() string         { return "List documents (Phase 2)" }
-func (*listCmd) Usage() string            { return "list: List documents (Phase 2)\n" }
-func (*listCmd) SetFlags(f *flag.FlagSet) {}
-func (*listCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
-	fmt.Fprintln(os.Stderr, "list command not yet implemented (Phase 2)")
-	return subcommands.ExitFailure
-}
 
 type createCmd struct{}
 


### PR DESCRIPTION
## Summary

- Implements Phase 2 list command as specified in doc/TODO-CLI.md
- Adds `list.go` with fully functional list command implementation
- Removes stub listCmd from `main.go`
- List command fetches documents from "new" location only and outputs pretty-printed JSON

## Implementation Details

- Uses `baseCommand` pattern for consistent client initialization
- Fetches documents using `ListDocumentsOptions{Location: LocationNew}`
- Outputs `response.Results` as pretty-printed JSON array
- Handles errors with proper exit codes (ExitFailure/ExitSuccess)
- Added TODO comment for future pagination implementation

## Test Plan

- [x] Build CLI successfully with `go build`
- [x] Verify `reader help` shows list command
- [x] Test `reader list` command with valid READWISE_ACCESS_TOKEN
- [x] Confirm pretty-printed JSON output format
- [x] Verify error handling for missing token

## Usage

```bash
export READWISE_ACCESS_TOKEN="your-token"
./reader list
```

Outputs JSON array of documents from the "new" location.