### PR TITLE
feat: add filtering flags to list command

### DIFF
--- a/doc/TODO-CLI.md
+++ b/doc/TODO-CLI.md
@@ -113,18 +113,33 @@ cmd/reader/
 
 ### List Command (`list.go`) ✅ IMPLEMENTED
 
-- ✅ Lists documents from "new" location only
+**Core Implementation:**
+- ✅ Lists documents with flexible filtering options
 - ✅ Outputs pretty-printed JSON array of documents
 - ✅ Uses baseCommand pattern for client initialization
 - ✅ Handles errors with proper exit codes
 - ✅ TODO added for future pagination implementation
 
+**Filtering Flags:** ✅ IMPLEMENTED
+- ✅ `--location` flag (new, later, archive, feed) - defaults to "new"
+- ✅ `--category` flag (article, email, rss, pdf, epub, tweet, video, highlight)
+- ✅ `--tag` flag for filtering by single tag name
+- ✅ Flag validation with helpful error messages
+- ✅ Support for combining multiple filters
+
+**Usage Examples:**
+```bash
+./reader list                           # Default: new location
+./reader list -location later           # Later location only
+./reader list -category article         # Articles only  
+./reader list -location new -category rss  # Combined filters
+./reader list -tag "ai"                 # Tag filtering
+```
+
 **TODO for future phases:**
-- Add `--location` flag (new, later, archive, feed)
-- Add `--category` flag (article, email, rss, pdf, epub, tweet, video, highlight)
-- Add `--tag` flag for filtering by tags
 - Add `--limit` flag for pagination control
 - Add `--updated-after` flag for time-based filtering
+- Add pagination support (currently single page only)
 
 ### Create Command (`create.go`) ✅ IMPLEMENTED
 


### PR DESCRIPTION
## Summary

- Adds comprehensive filtering flags to the `list` command
- Supports location, category, and tag filtering with proper validation
- Maintains backward compatibility while greatly enhancing functionality  
- Updates documentation with usage examples and implementation status

## Implementation Details

### Location Flag (`-location`)
- **Values**: `new`, `later`, `archive`, `feed`
- **Default**: `new` (maintains backward compatibility)
- **Validation**: Returns `ExitUsageError` with helpful message for invalid values
- **Mapping**: Properly maps string values to `reader.Location` enum constants

### Category Flag (`-category`)  
- **Values**: `article`, `email`, `rss`, `pdf`, `epub`, `tweet`, `video`, `highlight`
- **Default**: Empty (no filtering)
- **Validation**: Returns `ExitUsageError` with helpful message for invalid values
- **Mapping**: Properly maps string values to `reader.Category` enum constants

### Tag Flag (`-tag`)
- **Values**: Any string tag name
- **Default**: Empty (no filtering)  
- **Limitation**: Single tag only (matches API constraint)
- **Usage**: Filters documents containing the specified tag

### Enhanced Features
- ✅ **Flag Combination**: All filters can be used together
- ✅ **Input Validation**: Clear error messages for invalid enum values
- ✅ **Help Documentation**: Updated usage text with comprehensive examples
- ✅ **Backward Compatibility**: Existing `./reader list` usage unchanged
- ✅ **Exit Codes**: Proper `ExitUsageError` vs `ExitFailure` distinction

## Test Plan

- [x] Build CLI successfully with `go build`
- [x] Test default behavior: `./reader list` (defaults to new location)
- [x] Test location filtering: `./reader list -location later`
- [x] Test category filtering: `./reader list -category article`  
- [x] Test tag filtering: `./reader list -tag "ai"`
- [x] Test combined filters: `./reader list -location new -category rss`
- [x] Test invalid location: `./reader list -location invalid` (proper error)
- [x] Test invalid category: `./reader list -category invalid` (proper error)
- [x] Test help: `./reader list -h` (shows all flags)

## Usage Examples

```bash
# Default behavior (unchanged)
./reader list

# Filter by location
./reader list -location later
./reader list -location archive

# Filter by category  
./reader list -category article
./reader list -category rss

# Filter by tag
./reader list -tag "productivity"

# Combine multiple filters
./reader list -location new -category article
./reader list -location later -category rss -tag "ai"

# Get help
./reader list -h
```

## Documentation Updates

- Updated `TODO-CLI.md` to mark filtering flags as implemented
- Added usage examples and feature descriptions
- Moved completed flags from "TODO for future phases" to "✅ IMPLEMENTED"

This enhancement transforms the list command from a simple "new location only" tool into a powerful, flexible document filtering interface while maintaining the clean CLI design philosophy.