### PR TITLE
feat: add --since flag for time-based filtering to list command

### DIFF
--- a/doc/TODO-CLI.md
+++ b/doc/TODO-CLI.md
@@ -124,8 +124,15 @@ cmd/reader/
 - ✅ `--location` flag (new, later, archive, feed) - defaults to "new"
 - ✅ `--category` flag (article, email, rss, pdf, epub, tweet, video, highlight)
 - ✅ `--tag` flag for filtering by single tag name
+- ✅ `--since` flag for time-based filtering using Go duration format
 - ✅ Flag validation with helpful error messages
 - ✅ Support for combining multiple filters
+
+**Time-based Filtering (`--since`):** ✅ IMPLEMENTED
+- Uses standard Go `time.ParseDuration` for consistent behavior
+- Supports: seconds (`30s`), minutes (`30m`), hours (`24h`), complex (`1h30m`)
+- Calculates time "duration ago" from current time for `UpdatedAfter` API
+- Proper error handling for invalid duration formats
 
 **Usage Examples:**
 ```bash
@@ -134,11 +141,14 @@ cmd/reader/
 ./reader list -category article         # Articles only  
 ./reader list -location new -category rss  # Combined filters
 ./reader list -tag "ai"                 # Tag filtering
+./reader list -since 1h                 # Documents updated in last hour
+./reader list -since 24h                # Documents updated in last day
+./reader list -since 1h30m              # Documents updated in last 1.5 hours
+./reader list -since 24h -category article  # Recent articles
 ```
 
 **TODO for future phases:**
 - Add `--limit` flag for pagination control
-- Add `--updated-after` flag for time-based filtering
 - Add pagination support (currently single page only)
 
 ### Create Command (`create.go`) ✅ IMPLEMENTED


### PR DESCRIPTION
## Summary

- Adds `--since` flag to the `list` command for time-based document filtering
- Uses Go's standard `time.ParseDuration` for consistent, familiar duration parsing
- Integrates seamlessly with existing filtering flags (location, category, tag)
- Updates documentation with comprehensive usage examples

## Implementation Details

### Since Flag (`--since`)
- **Format**: Standard Go duration format via `time.ParseDuration`
- **Supported Units**: 
  - Seconds: `30s`, `3600s`
  - Minutes: `30m`, `90m`
  - Hours: `1h`, `24h`, `48h`
  - Complex: `1h30m`, `2h45m30s`
- **Calculation**: Subtracts duration from current time to create `UpdatedAfter` timestamp
- **Validation**: Returns `ExitUsageError` with helpful message for invalid formats

### API Integration
- Maps to `ListDocumentsOptions.UpdatedAfter` field
- Properly handles `*time.Time` type expected by the API
- Uses `time.Now().Add(-duration)` for accurate relative time calculation

### Enhanced Features
- ✅ **Filter Combination**: Works with all existing filters
- ✅ **Input Validation**: Clear error messages for invalid duration formats
- ✅ **Help Documentation**: Updated usage text with examples
- ✅ **Go Standards**: Uses familiar Go duration syntax
- ✅ **Exit Codes**: Proper `ExitUsageError` for validation failures

## Test Plan

- [x] Build CLI successfully with `go build`
- [x] Test various duration formats:
  - [x] `./reader list --since 1h` (simple hour)
  - [x] `./reader list --since 30m` (minutes)
  - [x] `./reader list --since 48h` (multiple days as hours)
  - [x] `./reader list --since 1h30m` (complex format)
- [x] Test error handling: `./reader list --since invalid` (proper error)
- [x] Test filter combinations: `./reader list --since 24h --category article`
- [x] Test help: `./reader list -h` (shows since flag)

## Usage Examples

```bash
# Basic time filtering
./reader list --since 1h           # Documents updated in last hour
./reader list --since 30m          # Documents updated in last 30 minutes
./reader list --since 24h          # Documents updated in last day
./reader list --since 48h          # Documents updated in last 2 days

# Complex duration formats
./reader list --since 1h30m        # Documents updated in last 1.5 hours
./reader list --since 2h45m30s     # Very specific timeframe

# Combined with other filters
./reader list --since 24h --category article       # Recent articles
./reader list --since 12h --location later         # Recent items in later
./reader list --since 6h --tag "ai" --category rss # Recent AI RSS items

# Error handling
./reader list --since 2d           # Error: invalid format (days not supported)
./reader list --since invalid      # Error: with helpful message
```

## Documentation Updates

- Updated `TODO-CLI.md` to mark time-based filtering as implemented
- Added dedicated section for `--since` flag with technical details
- Expanded usage examples to show time-based filtering combinations
- Removed `--updated-after` from TODO list (replaced by `--since`)

## Benefits

1. **Standard Behavior**: Uses Go's built-in duration parsing for consistency
2. **User Friendly**: Familiar syntax for Go developers
3. **Flexible**: Supports wide range of time formats from seconds to days
4. **Robust**: Proper validation and error handling
5. **Composable**: Works seamlessly with existing filter architecture

This enhancement provides powerful time-based document filtering while maintaining the CLI's clean, intuitive design philosophy.