### PR TITLE
Add comprehensive flags to create command

### DIFF
--- a/cmd/reader/go.mod
+++ b/cmd/reader/go.mod
@@ -6,3 +6,5 @@ require (
 	github.com/google/subcommands v1.2.0
 	github.com/tcnksm/go-readwise-reader v0.0.0-20250720014538-4e24fff434fa
 )
+
+replace github.com/tcnksm/go-readwise-reader => ../../

--- a/cmd/reader/go.sum
+++ b/cmd/reader/go.sum
@@ -1,12 +1,2 @@
 github.com/google/subcommands v1.2.0 h1:vWQspBTo2nEqTUFita5/KeEWlUL8kQObDFbub/EN9oE=
 github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
-github.com/tcnksm/go-readwise-reader v0.0.0-20250719025658-07680740a207 h1:943zAdUgjpstm4ycnG+EKuvw/BMiOShLJ68Y9+krjtY=
-github.com/tcnksm/go-readwise-reader v0.0.0-20250719025658-07680740a207/go.mod h1:oaFFzzo2WzSI71Ud/3dKnNwmrqwqqMp5gfsDoQ3IIow=
-github.com/tcnksm/go-readwise-reader v0.0.0-20250719071108-87d52b7ecfdc h1:FVzYkWN4Vnou/h7j66IRXm6R2M/okY3PREFRQoVazgA=
-github.com/tcnksm/go-readwise-reader v0.0.0-20250719071108-87d52b7ecfdc/go.mod h1:oaFFzzo2WzSI71Ud/3dKnNwmrqwqqMp5gfsDoQ3IIow=
-github.com/tcnksm/go-readwise-reader v0.0.0-20250720005848-81347591e15c h1:GwSI6Uj5Ec/I3yHZpftty/mZfaJYZ2j97j/Z1tc9XKg=
-github.com/tcnksm/go-readwise-reader v0.0.0-20250720005848-81347591e15c/go.mod h1:oaFFzzo2WzSI71Ud/3dKnNwmrqwqqMp5gfsDoQ3IIow=
-github.com/tcnksm/go-readwise-reader v0.0.0-20250720013844-7b7bb7ce2c9f h1:cQXw2AuR9l5F9g02MOWsgE4AFwzfWAE8CohchGL91fQ=
-github.com/tcnksm/go-readwise-reader v0.0.0-20250720013844-7b7bb7ce2c9f/go.mod h1:oaFFzzo2WzSI71Ud/3dKnNwmrqwqqMp5gfsDoQ3IIow=
-github.com/tcnksm/go-readwise-reader v0.0.0-20250720014538-4e24fff434fa h1:PhaPFm9iJ/fYD8wZt1lTfb5mqeIsqF1o1b3zBI+kNME=
-github.com/tcnksm/go-readwise-reader v0.0.0-20250720014538-4e24fff434fa/go.mod h1:oaFFzzo2WzSI71Ud/3dKnNwmrqwqqMp5gfsDoQ3IIow=

--- a/create.go
+++ b/create.go
@@ -42,6 +42,10 @@ type CreateDocumentRequest struct {
 
 	// Notes is A top-level note of the document (optional)
 	Notes string `json:"notes,omitempty"`
+
+	// ShouldCleanHTML instructs Readwise to clean the provided HTML and parse metadata (optional)
+	// Only valid when HTML is provided. Defaults to false.
+	ShouldCleanHTML bool `json:"should_clean_html,omitempty"`
 }
 
 // CreateDocumentResponse represents the response from creating a document


### PR DESCRIPTION
## Summary
- Add -location, -notes, -summary, -title, -author, -html flags to create command
- Add ShouldCleanHTML field to CreateDocumentRequest API struct
- Enable automatic HTML cleaning when -html flag is provided
- Update command usage documentation with new flags

## Test plan
- [x] Build succeeds without errors
- [x] Code formatting and vet checks pass
- [x] Help output displays new flags correctly
- [ ] Manual testing with various flag combinations
- [ ] Integration testing with Readwise API