### PR TITLE
Add stdin support for HTML content in create command

### DIFF
--- a/cmd/reader/create.go
+++ b/cmd/reader/create.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/google/subcommands"
@@ -37,7 +38,7 @@ func (*createCmd) Usage() string {
     -summary string      Brief summary of the document
     -title string        Document title
     -author string       Document author
-    -html string         Document content in valid HTML format
+    -html string         Document content in valid HTML format (use "-" to read from stdin)
 `
 }
 func (c *createCmd) SetFlags(f *flag.FlagSet) {
@@ -85,7 +86,17 @@ func (c *createCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface
 		req.Author = c.author
 	}
 	if c.html != "" {
-		req.HTML = c.html
+		if c.html == "-" {
+			// Read HTML content from stdin
+			htmlBytes, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				printError(fmt.Errorf("failed to read HTML from stdin: %w", err))
+				return subcommands.ExitFailure
+			}
+			req.HTML = string(htmlBytes)
+		} else {
+			req.HTML = c.html
+		}
 		// Enable HTML cleaning when HTML is provided
 		req.ShouldCleanHTML = true
 	}


### PR DESCRIPTION
## Summary
- Enable reading HTML content from stdin when using `-html -` flag
- Add proper error handling for stdin read failures  
- Update help text to document the new stdin feature

## Use Cases
This enhancement allows users to pipe HTML content directly to the create command:

```bash
# Pipe HTML content from echo
echo '<h1>Title</h1><p>Content</p>' | reader create -html - http://example.com

# Read HTML from file
cat document.html | reader create -html - http://example.com

# Generate HTML and pipe to reader
pandoc document.md -t html | reader create -html - http://example.com
```

## Test Plan
- [x] Build successfully with `go build`
- [x] Code quality checks pass (`go fmt`, `go vet`)  
- [x] Help text shows updated documentation
- [x] Basic functionality test with echo piping HTML
- [x] Edge case test with empty stdin input
- [x] Backward compatibility maintained for direct HTML strings