### PR TITLE
Add missing fields to UpdateDocumentRequest

### DIFF
--- a/update.go
+++ b/update.go
@@ -26,6 +26,13 @@ type UpdateDocumentRequest struct {
 	// ImageURL is the document image URL
 	ImageURL string `json:"image_url,omitempty"`
 
+	// Seen marks the document as opened. When true, populates first_opened_at/last_opened_at.
+	// When false, clears these timestamps.
+	Seen *bool `json:"seen,omitempty"`
+
+	// Tags is a list of tags to associate with the document
+	Tags []string `json:"tags,omitempty"`
+
 	// Location is where the document should be stored
 	Location Location `json:"location,omitempty"`
 

--- a/update_test.go
+++ b/update_test.go
@@ -73,6 +73,23 @@ func TestUpdateDocument(t *testing.T) {
 			wantURL: "https://read.readwise.io/read/doc789",
 		},
 		{
+			name:       "successful update with tags and seen",
+			documentID: "doc999",
+			req: &UpdateDocumentRequest{
+				Title: "Article with Tags",
+				Tags:  []string{"golang", "api", "readwise"},
+				Seen:  boolPtr(true),
+			},
+			responseStatus: http.StatusOK,
+			responseBody: UpdateDocumentResponse{
+				ID:  "doc999",
+				URL: "https://read.readwise.io/read/doc999",
+			},
+			wantErr: false,
+			wantID:  "doc999",
+			wantURL: "https://read.readwise.io/read/doc999",
+		},
+		{
 			name:       "empty document ID",
 			documentID: "",
 			req: &UpdateDocumentRequest{
@@ -215,4 +232,9 @@ func TestUpdateDocument_ContextCancellation(t *testing.T) {
 	if err == nil {
 		t.Error("expected error due to cancelled context, got nil")
 	}
+}
+
+// boolPtr returns a pointer to the given bool value
+func boolPtr(b bool) *bool {
+	return &b
 }


### PR DESCRIPTION
## Summary

Add missing `Seen` and `Tags` fields to `UpdateDocumentRequest` to support all fields available in the Readwise Reader API UPDATE endpoint (https://readwise.io/reader_api).

- **Seen** (`*bool`): Marks the document as opened. When `true`, populates `first_opened_at`/`last_opened_at`. When `false`, clears these timestamps.
- **Tags** (`[]string`): A list of tags to associate with the document.

## Changes

- Added `Seen` field to `UpdateDocumentRequest` in `update.go`
- Added `Tags` field to `UpdateDocumentRequest` in `update.go`
- Added test case "successful update with tags and seen" in `update_test.go`
- Added `boolPtr` helper function for testing bool pointers

## Test plan

- [x] All existing tests pass
- [x] Added new test case covering both new fields
- [x] Code formatted with `go fmt`
- [x] Code vetted with `go vet`

🤖 Generated with [Claude Code](https://claude.com/claude-code)